### PR TITLE
Chore: sanitise package.json for bin names

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   "files": [
     "dist"
   ],
-  "bin": "dist/microbundle.js",
+  "bin": {
+    "microbundle-2": "dist/microbundle.js",
+    "microbundle": "dist/microbundle.js"
+  },
   "scripts": {
     "build": "node scripts/build.mjs",
     "watch": "node scripts/build.mjs --watch"
@@ -31,5 +34,6 @@
   },
   "prettier": {
     "singleQuote": true
-  }
+  },
+  "packageManager": "pnpm@8.15.9"  
 }


### PR DESCRIPTION
Builds using `microbundle` doesn't work as the `bin` field picks up the original name of the packages. 

This PR adds 2 things 
1. Passive Locks the PNPM version so others can contribute without making massive changes to the lock file 
2. Adds the binary names to match with the docs