### PR TITLE
Fix: avoid resolving unknown extensions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,8 @@ function prettyBytes(value: number) {
 	return `${value}${dim('b')}`;
 }
 
+const EXCLUDED_EXTENSIONS = [/\.json$/,/\.d\.([cm]?ts)$/]
+
 interface Args {
 	cwd: string;
 	sourcemap?: boolean;
@@ -265,7 +267,7 @@ async function build(args: BuildArgs) {
 		formatsWithoutCjs.map((format) => {
 			const ext = extForFormat(format);
 
-			const eps = entryPoints.map((input, index) => ({
+			const eps = entryPoints.filter(file=>!EXCLUDED_EXTENSIONS.some(extRgx=>extRgx.test(file))).map((input, index) => ({
 				in: input,
 				out: exports[entryPaths[index]].find(m => {
 					if (format === 'cjs' && m.conditions.includes('require')) return true;
@@ -284,7 +286,7 @@ async function build(args: BuildArgs) {
 					}
 				}
 				return last;
-			}).join('/');
+			}).join('/') || "."; // outdir might be an empty string in case of root level exports
 			for (const ep of eps) ep.out = relative(outdir, ep.out);
 			// const mkdirDone = mkdir(outdir);
 


### PR DESCRIPTION
> current setup doesn't support resolving type defs and json files

The PR makes 
- a tiny change to avoid resolving `package.json` and different type definitions
- fixes when the root directory is the common output folder 
   - In an export definition like below, the common out folder would be the root directory thus making the logic output `outdir` as `""` instead of `"."` 

```json
{
  "exports": {
    ".": {
      "types": {
        "require": "./dist/cjs/index.d.ts",
        "import": "./dist/esm/index.d.ts"
      },
      "require": "./dist/cjs/index.cjs",
      "import": "./dist/esm/index.mjs",
      "default": "./dist/esm/index.mjs"
    },
    "./package.json": "./package.json"
  }
}
```